### PR TITLE
Add text-to-speech and random answer sounds

### DIFF
--- a/src/AudioManager.ts
+++ b/src/AudioManager.ts
@@ -31,6 +31,8 @@ export class AudioManager {
     public readonly MUSIC_GAME_END: HTMLAudioElement;
     public readonly MUSIC_GAME_START: HTMLAudioElement;
     public readonly DONE_READING_CLUE_QUESTION: HTMLAudioElement;
+    public readonly ANSWER_CORRECT_ALTS: HTMLAudioElement[];
+    public readonly ANSWER_WRONG_ALTS: HTMLAudioElement[];
 
     public constructor() {
         this.ANSWER_CORRECT = querySelectorAndCheck<HTMLAudioElement>(document, "audio#answer-correct");
@@ -43,6 +45,8 @@ export class AudioManager {
         this.MUSIC_GAME_END = querySelectorAndCheck<HTMLAudioElement>(document, "audio#music-game-end");
         this.MUSIC_GAME_START = querySelectorAndCheck<HTMLAudioElement>(document, "audio#music-game-start");
         this.DONE_READING_CLUE_QUESTION = querySelectorAndCheck<HTMLAudioElement>(document, "audio#done-reading-clue-question");
+        this.ANSWER_CORRECT_ALTS = Array.from(document.querySelectorAll<HTMLAudioElement>("audio.answer-correct-alt"));
+        this.ANSWER_WRONG_ALTS = Array.from(document.querySelectorAll<HTMLAudioElement>("audio.answer-wrong-alt"));
     }
 
     public playInOrder(...audioElements: HTMLAudioElement[]): void {
@@ -73,5 +77,17 @@ export class AudioManager {
 
         allAudioElements[indexToPlayNow].addEventListener("ended", onAudioEnd);
         allAudioElements[indexToPlayNow].play();
+    }
+
+    public playRandomCorrectSound(): void {
+        const pool = [this.ANSWER_CORRECT, ...this.ANSWER_CORRECT_ALTS];
+        const clip = pool[Math.floor(Math.random() * pool.length)];
+        clip.play();
+    }
+
+    public playRandomWrongSound(): void {
+        const pool = [this.ANSWER_WRONG_OR_ANSWER_TIMEOUT, ...this.ANSWER_WRONG_ALTS];
+        const clip = pool[Math.floor(Math.random() * pool.length)];
+        clip.play();
     }
 }

--- a/src/Team.ts
+++ b/src/Team.ts
@@ -96,7 +96,7 @@ export class Team {
 
     public onAnswerCorrect(clue: RevealedClue): void {
         this.answerStop();
-        this.AUDIO_MANAGER.ANSWER_CORRECT.play();
+        this.AUDIO_MANAGER.playRandomCorrectSound();
         this.moneyAdd(clue.VALUE);
         this.statistics.questionsBuzzedThenAnsweredRight++;
         this.hasBuzzedForCurrentQuestion_ = true;
@@ -104,7 +104,7 @@ export class Team {
 
     public onAnswerIncorrectOrAnswerTimeout(clue: RevealedClue): void {
         this.answerStop();
-        this.AUDIO_MANAGER.ANSWER_WRONG_OR_ANSWER_TIMEOUT.play();
+        this.AUDIO_MANAGER.playRandomWrongSound();
         this.moneySubtract(clue.VALUE * this.SETTINGS.wrongAnswerPenaltyMultiplier);
         this.setState(this.SETTINGS.allowMultipleAnswersToSameQuestion ? "can-answer" : "already-answered-this-clue");
         this.statistics.questionsBuzzedThenAnsweredWrongOrTimedOut++;

--- a/src/TextToSpeechManager.ts
+++ b/src/TextToSpeechManager.ts
@@ -1,0 +1,97 @@
+import { GameRound, RevealedClue } from "./typesForGame";
+
+export class TextToSpeechManager {
+    private readonly apiKey: string;
+    private readonly voiceId: string;
+    private queue: { id: string; text: string }[] = [];
+    private fetching = false;
+    private abortController: AbortController | null = null;
+    private activeTask: { id: string; text: string } | null = null;
+    private readonly audioCache = new Map<string, HTMLAudioElement>();
+
+    public constructor(apiKey: string, voiceId: string) {
+        this.apiKey = apiKey;
+        this.voiceId = voiceId;
+    }
+
+    public startRound(gameRound: GameRound, roundIndex: number): void {
+        gameRound.CLUES.forEach(row => {
+            row.forEach(clue => {
+                if (clue.REVEALED_ON_TV_SHOW) {
+                    this.queue.push({
+                        id: this.getId(roundIndex, clue.ROW_INDEX, clue.COLUMN_INDEX),
+                        text: clue.QUESTION
+                    });
+                }
+            });
+        });
+        void this.processQueue();
+    }
+
+    public async playQuestion(roundIndex: number, clue: RevealedClue): Promise<void> {
+        const id = this.getId(roundIndex, clue.ROW_INDEX, clue.COLUMN_INDEX);
+        const cached = this.audioCache.get(id);
+        if (cached) {
+            cached.play();
+            return;
+        }
+        const audio = await this.fetchImmediate(id, clue.QUESTION);
+        audio.play();
+    }
+
+    private getId(round: number, row: number, col: number): string {
+        return `${round}-${row}-${col}`;
+    }
+
+    private async fetchImmediate(id: string, text: string): Promise<HTMLAudioElement> {
+        if (this.abortController) {
+            this.abortController.abort();
+            if (this.activeTask) {
+                this.queue.unshift(this.activeTask);
+            }
+        }
+        const audio = await this.fetchAudio(id, text);
+        void this.processQueue();
+        return audio;
+    }
+
+    private async fetchAudio(id: string, text: string): Promise<HTMLAudioElement> {
+        this.abortController = new AbortController();
+        this.activeTask = { id, text };
+        const response = await fetch(`https://api.elevenlabs.io/v1/text-to-speech/${this.voiceId}`,
+            {
+                method: "POST",
+                headers: {
+                    "xi-api-key": this.apiKey,
+                    "Content-Type": "application/json"
+                },
+                body: JSON.stringify({ text }),
+                signal: this.abortController.signal
+            });
+        const blob = await response.blob();
+        const url = URL.createObjectURL(blob);
+        const audio = new Audio(url);
+        this.audioCache.set(id, audio);
+        this.abortController = null;
+        this.activeTask = null;
+        return audio;
+    }
+
+    private async processQueue(): Promise<void> {
+        if (this.fetching) {
+            return;
+        }
+        this.fetching = true;
+        while (this.queue.length > 0) {
+            const task = this.queue.shift()!;
+            try {
+                await this.fetchAudio(task.id, task.text);
+            } catch (er) {
+                if ((er as Error).name !== "AbortError") {
+                    console.error("TTS fetch error", er);
+                }
+            }
+        }
+        this.fetching = false;
+    }
+}

--- a/src/operator/Operator.ts
+++ b/src/operator/Operator.ts
@@ -4,6 +4,7 @@ import { CountdownTimer } from "../CountdownTimer";
 import { FinalJeopardyTable } from "../FinalJeopardyTable";
 import { GameBoard } from "../GameBoard";
 import { Settings } from "../Settings";
+import { TextToSpeechManager } from "../TextToSpeechManager";
 import { Team, TeamSavedInLocalStorage, TeamState } from "../Team";
 import { querySelectorAndCheck } from "../commonFunctions";
 import { createGameEndLineChartOfMoneyOverTime, createGameEndPieChartsOfBuzzResults } from "../gameEndStatisticsCharts";
@@ -28,6 +29,7 @@ export class Operator {
 
     private readonly AUDIO_MANAGER: AudioManager;
     private readonly SETTINGS: Settings;
+    private readonly TTS_MANAGER: TextToSpeechManager;
     private readonly DIV_CLUE_WRAPPER: HTMLDivElement;
     private readonly DIV_CLUE_QUESTION: HTMLDivElement;
     private readonly DIV_CLUE_VALUE: HTMLDivElement;
@@ -89,9 +91,10 @@ export class Operator {
     private categoryCarouselIndex = -1;
     private teamIndexToPickClue = 0;
 
-    public constructor(audioManager: AudioManager, settings: Settings) {
+    public constructor(audioManager: AudioManager, settings: Settings, ttsManager: TextToSpeechManager) {
         this.AUDIO_MANAGER = audioManager;
         this.SETTINGS = settings;
+        this.TTS_MANAGER = ttsManager;
 
         this.DIV_CLUE_WRAPPER = querySelectorAndCheck(document, "div#clue-wrapper");
         this.DIV_CLUE_QUESTION = querySelectorAndCheck(document, "div#div-clue-question");
@@ -756,6 +759,8 @@ export class Operator {
         this.TR_QUESTION.style.display = ""; //show it by removing "display=none"
         this.TR_ANSWER.style.display = "none";
 
+        void this.TTS_MANAGER.playQuestion(this.gameRoundIndex, this.presentClue);
+
         // this.specialCategoryPromptHide();
     }
 
@@ -1218,6 +1223,7 @@ export class Operator {
     public gameRoundStartNext(): void {
         this.gameRoundIndex++;
         const gameRound = SCRAPED_GAME.ROUNDS[this.gameRoundIndex];
+        this.TTS_MANAGER.startRound(gameRound, this.gameRoundIndex);
         gameRound.CATEGORIES.forEach(category => category.specialCategory = checkSpecialCategory(category.NAME));
         this.gameBoard?.setGameRound(gameRound);
         this.DIV_CLUE_WRAPPER.style.display = "none";

--- a/src/operator/main.ts
+++ b/src/operator/main.ts
@@ -1,10 +1,12 @@
 import { AudioManager } from "../AudioManager";
 import { Settings } from "../Settings";
+import { TextToSpeechManager } from "../TextToSpeechManager";
 import { Operator } from "./Operator";
 
 document.addEventListener("DOMContentLoaded", function () {
     const settings = new Settings();
     const audioManager = new AudioManager();
+    const ttsManager = new TextToSpeechManager("YOUR_ELEVENLABS_API_KEY", "VOICE_ID");
 
     window.addEventListener("error", function (errorEvent) {
         const errorDiv = document.createElement("div");
@@ -20,6 +22,6 @@ document.addEventListener("DOMContentLoaded", function () {
 
     // Add global variable so we can access the operator instance in the web browser debugger.
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
-    (window as any).operator = new Operator(audioManager, settings);
+    (window as any).operator = new Operator(audioManager, settings, ttsManager);
 
 });

--- a/src/operator/operator.html
+++ b/src/operator/operator.html
@@ -321,7 +321,11 @@
 
         <div style="display:none">
             <audio preload="auto" src="../sound/answer-correct.mp3" id="answer-correct"></audio>
+            <audio preload="auto" src="../sound/answer-correct.mp3" class="answer-correct-alt"></audio>
+            <audio preload="auto" src="../sound/answer-correct.mp3" class="answer-correct-alt"></audio>
             <audio preload="auto" src="../sound/answer-incorrect.mp3" id="answer-incorrect"></audio>
+            <audio preload="auto" src="../sound/answer-incorrect.mp3" class="answer-wrong-alt"></audio>
+            <audio preload="auto" src="../sound/answer-incorrect.mp3" class="answer-wrong-alt"></audio>
             <audio preload="auto" src="../sound/question-timeout.mp3" id="question-timeout"></audio>
             <audio preload="auto" src="../sound/round-end.wav" id="round-end"></audio>
             <audio preload="auto" src="../sound/team-buzz.wav" id="team-buzz"></audio>


### PR DESCRIPTION
## Summary
- introduce `TextToSpeechManager` for ElevenLabs API integration
- start pre-fetching clue audio when a round begins
- play clue audio with priority when the question is shown
- play random correct/wrong answer clips
- wire new TTS manager into the operator startup
- update operator HTML with extra audio tags

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find module '../scrapedGame')*

------
https://chatgpt.com/codex/tasks/task_e_68782cff6b08832c94d8588f865f28c6