### PR TITLE
Fix airdate parsing for random games

### DIFF
--- a/src/jservice.ts
+++ b/src/jservice.ts
@@ -87,10 +87,18 @@ export async function fetchRandomGame(): Promise<Game> {
             ANSWER: finalClue.answer,
         };
 
+        const airdate = new Date(finalClue.airdate);
+        const formattedAirdate = airdate.toLocaleDateString('en-US', {
+            weekday: 'long',
+            month: 'long',
+            day: 'numeric',
+            year: 'numeric',
+        });
+
         return {
             J_ARCHIVE_GAME_ID: finalClue.game_id,
             SHOW_NUMBER: finalClue.game_id,
-            AIRDATE: new Date().toDateString(),
+            AIRDATE: formattedAirdate,
             ROUNDS: rounds,
             FINAL_JEOPARDY: final,
         };

--- a/src/localGames.ts
+++ b/src/localGames.ts
@@ -39,10 +39,16 @@ function createGame(id: number): Game {
     QUESTION: `Final question ${id}`,
     ANSWER: `Final answer ${id}`,
   };
+  const formattedAirdate = new Date().toLocaleDateString('en-US', {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  });
   return {
     J_ARCHIVE_GAME_ID: id,
     SHOW_NUMBER: id,
-    AIRDATE: new Date().toDateString(),
+    AIRDATE: formattedAirdate,
     ROUNDS: [singleRound, doubleRound],
     FINAL_JEOPARDY: finalJeopardy,
   };


### PR DESCRIPTION
## Summary
- ensure dates from JService and local games match the expected string format

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687ffb51231c832c98efbfdf5a255096