### PR TITLE
Fix question data by using OpenTDB as fallback

### DIFF
--- a/src/jservice.ts
+++ b/src/jservice.ts
@@ -15,6 +15,24 @@ export interface JServiceClue {
 import { Game, GameRound, Category, RevealedClue, FinalJeopardy, RoundType } from "./typesForGame";
 import { LOCAL_GAMES } from "./localGames";
 
+interface OpenTDBQuestion {
+    category: string;
+    type: string;
+    difficulty: string;
+    question: string;
+    correct_answer: string;
+    incorrect_answers: string[];
+}
+
+function decodeHtml(str: string): string {
+    return str
+        .replace(/&amp;/g, "&")
+        .replace(/&quot;/g, '"')
+        .replace(/&#039;/g, "'")
+        .replace(/&lt;/g, "<")
+        .replace(/&gt;/g, ">");
+}
+
 async function fetchJson(url: string): Promise<any> {
     const response = await fetch(url);
     if (!response.ok) {
@@ -35,6 +53,88 @@ async function fetchCategories(count: number): Promise<{ id: number; title: stri
 
 async function fetchCluesForCategory(catId: number): Promise<JServiceClue[]> {
     return await fetchJson(`https://jservice.io/api/clues?category=${catId}`);
+}
+
+async function fetchOTDBCategories(): Promise<{ id: number; name: string }[]> {
+    const data = await fetchJson("https://opentdb.com/api_category.php");
+    return data.trivia_categories;
+}
+
+async function fetchOTDBQuestions(catId: number): Promise<OpenTDBQuestion[]> {
+    const data = await fetchJson(`https://opentdb.com/api.php?amount=5&category=${catId}`);
+    if (data.response_code !== 0 || data.results.length < 5) {
+        throw new Error("Not enough questions from opentdb");
+    }
+    return data.results;
+}
+
+function createOTDBRound(type: RoundType, categories: { id: number; name: string }[], questionsPerCat: OpenTDBQuestion[][]): GameRound {
+    const categoriesOut: Category[] = categories.map(c => ({ NAME: c.name }));
+    const cluesRows: RevealedClue[][] = Array.from({ length: 5 }, () => Array(categories.length));
+    categories.forEach((cat, col) => {
+        const questions = questionsPerCat[col];
+        for (let row = 0; row < 5; row++) {
+            const q = questions[row];
+            cluesRows[row][col] = {
+                REVEALED_ON_TV_SHOW: true,
+                QUESTION: decodeHtml(q.question),
+                ANSWER: decodeHtml(q.correct_answer),
+                VALUE: (row + 1) * 200 * (type === "double" ? 2 : 1),
+                CATEGORY_NAME: cat.name,
+                ROW_INDEX: row,
+                COLUMN_INDEX: col,
+            };
+        }
+    });
+    return { TYPE: type, CATEGORIES: categoriesOut, CLUES: cluesRows };
+}
+
+async function fetchOpenTDBGame(): Promise<Game> {
+    const allCategories = await fetchOTDBCategories();
+    function pickRandomCats(): { id: number; name: string }[] {
+        const cats = [...allCategories];
+        const result = [] as { id: number; name: string }[];
+        for (let i = 0; i < 6; i++) {
+            const index = Math.floor(Math.random() * cats.length);
+            result.push(cats.splice(index, 1)[0]);
+        }
+        return result;
+    }
+
+    const roundTypes: RoundType[] = ["single", "double"];
+    const rounds: GameRound[] = [];
+    for (const type of roundTypes) {
+        const categories = pickRandomCats();
+        const questionsPerCat: OpenTDBQuestion[][] = [];
+        for (const cat of categories) {
+            const questions = await fetchOTDBQuestions(cat.id);
+            questionsPerCat.push(questions);
+        }
+        rounds.push(createOTDBRound(type, categories, questionsPerCat));
+    }
+
+    const finalData = await fetchJson("https://opentdb.com/api.php?amount=1");
+    const finalQ: OpenTDBQuestion = finalData.results[0];
+    const final: FinalJeopardy = {
+        CATEGORY: decodeHtml(finalQ.category),
+        QUESTION: decodeHtml(finalQ.question),
+        ANSWER: decodeHtml(finalQ.correct_answer),
+    };
+
+    const formattedAirdate = new Date().toLocaleDateString('en-US', {
+        weekday: 'long',
+        month: 'long',
+        day: 'numeric',
+        year: 'numeric',
+    });
+
+    return {
+        J_ARCHIVE_GAME_ID: 0,
+        SHOW_NUMBER: 0,
+        AIRDATE: formattedAirdate,
+        ROUNDS: rounds,
+        FINAL_JEOPARDY: final,
+    };
 }
 
 function toCategory(obj: { title: string }): Category {
@@ -103,7 +203,11 @@ export async function fetchRandomGame(): Promise<Game> {
             FINAL_JEOPARDY: final,
         };
     } catch (er) {
-        const randomIndex = Math.floor(Math.random() * LOCAL_GAMES.length);
-        return LOCAL_GAMES[randomIndex];
+        try {
+            return await fetchOpenTDBGame();
+        } catch {
+            const randomIndex = Math.floor(Math.random() * LOCAL_GAMES.length);
+            return LOCAL_GAMES[randomIndex];
+        }
     }
 }


### PR DESCRIPTION
## Summary
- handle HTML entities for external question data
- add new OpenTDB-based game builder
- use OpenTDB fallback before local placeholders when jservice fails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ffcb3349c832ca93366d2c03494fd