### PR TITLE
Fix question data by using OpenTDB as fallback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
                 "d3-scale": "^4.0.2",
                 "d3-selection": "^3.0.0",
                 "d3-zoom": "^3.0.0",
+                "https-proxy-agent": "^7.0.6",
                 "node-fetch": "^2.7.0",
                 "tailwindcss": "^3.3.5"
             },
@@ -3830,6 +3831,15 @@
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
         },
+        "node_modules/agent-base": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14"
+            }
+        },
         "node_modules/ajv": {
             "version": "6.12.6",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -4800,7 +4810,6 @@
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
             "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ms": "^2.1.3"
@@ -5982,6 +5991,19 @@
             },
             "engines": {
                 "node": ">=12"
+            }
+        },
+        "node_modules/https-proxy-agent": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
             }
         },
         "node_modules/human-signals": {
@@ -7531,7 +7553,6 @@
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/msgpackr": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
         "d3-scale": "^4.0.2",
         "d3-selection": "^3.0.0",
         "d3-zoom": "^3.0.0",
+        "https-proxy-agent": "^7.0.6",
         "node-fetch": "^2.7.0",
         "tailwindcss": "^3.3.5"
     },

--- a/src/jservice.ts
+++ b/src/jservice.ts
@@ -15,8 +15,42 @@ export interface JServiceClue {
 import { Game, GameRound, Category, RevealedClue, FinalJeopardy, RoundType } from "./typesForGame";
 import { LOCAL_GAMES } from "./localGames";
 
+interface OpenTDBQuestion {
+    category: string;
+    type: string;
+    difficulty: string;
+    question: string;
+    correct_answer: string;
+    incorrect_answers: string[];
+}
+
+function decodeHtml(str: string): string {
+    return str
+        .replace(/&amp;/g, "&")
+        .replace(/&quot;/g, '"')
+        .replace(/&#039;/g, "'")
+        .replace(/&lt;/g, "<")
+        .replace(/&gt;/g, ">");
+}
+
 async function fetchJson(url: string): Promise<any> {
-    const response = await fetch(url);
+    let response: Response;
+    const proxy =
+        typeof process !== "undefined" &&
+        (process.env.https_proxy || process.env.HTTPS_PROXY || process.env.http_proxy || process.env.HTTP_PROXY);
+
+    if (proxy && typeof window === "undefined") {
+        try {
+            const { ProxyAgent } = await import("undici");
+            response = await fetch(url, { dispatcher: new ProxyAgent(proxy) });
+        } catch {
+            const { HttpsProxyAgent } = await import("https-proxy-agent");
+            response = await fetch(url, { agent: new HttpsProxyAgent(proxy) as any });
+        }
+    } else {
+        response = await fetch(url);
+    }
+
     if (!response.ok) {
         throw new Error(`HTTP ${response.status} fetching ${url}`);
     }
@@ -35,6 +69,88 @@ async function fetchCategories(count: number): Promise<{ id: number; title: stri
 
 async function fetchCluesForCategory(catId: number): Promise<JServiceClue[]> {
     return await fetchJson(`https://jservice.io/api/clues?category=${catId}`);
+}
+
+async function fetchOTDBCategories(): Promise<{ id: number; name: string }[]> {
+    const data = await fetchJson("https://opentdb.com/api_category.php");
+    return data.trivia_categories;
+}
+
+async function fetchOTDBQuestions(catId: number): Promise<OpenTDBQuestion[]> {
+    const data = await fetchJson(`https://opentdb.com/api.php?amount=5&category=${catId}`);
+    if (data.response_code !== 0 || data.results.length < 5) {
+        throw new Error("Not enough questions from opentdb");
+    }
+    return data.results;
+}
+
+function createOTDBRound(type: RoundType, categories: { id: number; name: string }[], questionsPerCat: OpenTDBQuestion[][]): GameRound {
+    const categoriesOut: Category[] = categories.map(c => ({ NAME: c.name }));
+    const cluesRows: RevealedClue[][] = Array.from({ length: 5 }, () => Array(categories.length));
+    categories.forEach((cat, col) => {
+        const questions = questionsPerCat[col];
+        for (let row = 0; row < 5; row++) {
+            const q = questions[row];
+            cluesRows[row][col] = {
+                REVEALED_ON_TV_SHOW: true,
+                QUESTION: decodeHtml(q.question),
+                ANSWER: decodeHtml(q.correct_answer),
+                VALUE: (row + 1) * 200 * (type === "double" ? 2 : 1),
+                CATEGORY_NAME: cat.name,
+                ROW_INDEX: row,
+                COLUMN_INDEX: col,
+            };
+        }
+    });
+    return { TYPE: type, CATEGORIES: categoriesOut, CLUES: cluesRows };
+}
+
+async function fetchOpenTDBGame(): Promise<Game> {
+    const allCategories = await fetchOTDBCategories();
+    function pickRandomCats(): { id: number; name: string }[] {
+        const cats = [...allCategories];
+        const result = [] as { id: number; name: string }[];
+        for (let i = 0; i < 6; i++) {
+            const index = Math.floor(Math.random() * cats.length);
+            result.push(cats.splice(index, 1)[0]);
+        }
+        return result;
+    }
+
+    const roundTypes: RoundType[] = ["single", "double"];
+    const rounds: GameRound[] = [];
+    for (const type of roundTypes) {
+        const categories = pickRandomCats();
+        const questionsPerCat: OpenTDBQuestion[][] = [];
+        for (const cat of categories) {
+            const questions = await fetchOTDBQuestions(cat.id);
+            questionsPerCat.push(questions);
+        }
+        rounds.push(createOTDBRound(type, categories, questionsPerCat));
+    }
+
+    const finalData = await fetchJson("https://opentdb.com/api.php?amount=1");
+    const finalQ: OpenTDBQuestion = finalData.results[0];
+    const final: FinalJeopardy = {
+        CATEGORY: decodeHtml(finalQ.category),
+        QUESTION: decodeHtml(finalQ.question),
+        ANSWER: decodeHtml(finalQ.correct_answer),
+    };
+
+    const formattedAirdate = new Date().toLocaleDateString('en-US', {
+        weekday: 'long',
+        month: 'long',
+        day: 'numeric',
+        year: 'numeric',
+    });
+
+    return {
+        J_ARCHIVE_GAME_ID: 0,
+        SHOW_NUMBER: 0,
+        AIRDATE: formattedAirdate,
+        ROUNDS: rounds,
+        FINAL_JEOPARDY: final,
+    };
 }
 
 function toCategory(obj: { title: string }): Category {
@@ -103,7 +219,11 @@ export async function fetchRandomGame(): Promise<Game> {
             FINAL_JEOPARDY: final,
         };
     } catch (er) {
-        const randomIndex = Math.floor(Math.random() * LOCAL_GAMES.length);
-        return LOCAL_GAMES[randomIndex];
+        try {
+            return await fetchOpenTDBGame();
+        } catch {
+            const randomIndex = Math.floor(Math.random() * LOCAL_GAMES.length);
+            return LOCAL_GAMES[randomIndex];
+        }
     }
 }


### PR DESCRIPTION
## Summary
- handle HTML entities for external question data
- add new OpenTDB-based game builder
- use OpenTDB fallback before local placeholders when jservice fails
- support proxy settings for API requests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687ffcb3349c832ca93366d2c03494fd